### PR TITLE
make the metric name configurable

### DIFF
--- a/app/exporter.py
+++ b/app/exporter.py
@@ -9,16 +9,17 @@ import logging
 
 
 class MetricExporter:
-    def __init__(self, endpoint, aggregate, interval, extra_labels):
+    def __init__(self, endpoint, aggregate, interval, name, extra_labels):
         self.endpoint = endpoint
         self.aggregate = aggregate
         self.interval = interval
+        self.name = name
         self.extra_labels = extra_labels
         self.labels = set([aggregate])
         if extra_labels is not None:
             self.labels.update(extra_labels.keys())
         self.kubernetes_daily_cost_usd = Gauge(
-            "kubernetes_daily_cost_usd", "Kubernetes daily cost in USD aggregated by %s" % self.aggregate, self.labels)
+            self.name, "Kubernetes daily cost in USD aggregated by %s" % self.aggregate, self.labels)
 
     def run_metrics_loop(self):
         while True:

--- a/main.py
+++ b/main.py
@@ -27,6 +27,8 @@ def get_args():
                         help="Exporter's port (default: 9090)")
     parser.add_argument("-i", "--interval", default=60, type=int,
                         help="Update interval in seconds (default: 60)")
+    parser.add_argument("-n", "--name", default="kubernetes_daily_cost_usd",
+                        help="Name of the exposed metric (default: kubernetes_daily_cost_usd)")
     parser.add_argument("-e", "--endpoint", default="http://kubecost-cost-analyzer.monitoring.svc:9003",
                         help="Kubecost service endpoint (default: http://kubecost-cost-analyzer.monitoring.svc:9003)")
     parser.add_argument("-a", "--aggregate", default="namespace",
@@ -44,6 +46,7 @@ def main(args):
         endpoint=args.endpoint,
         aggregate=args.aggregate,
         interval=args.interval,
+        name=args.name,
         extra_labels=args.label
     )
     start_http_server(args.port)


### PR DESCRIPTION
Now we can use `-n` or `--name` to specify the exposed metric name. Its default value is `kubernetes_daily_cost_usd`.