### PR TITLE
update query based on the latest version of Kubecost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
     "name": "kubernetes-cost-exporter",
-    "version": "v1.0.4"
+    "version": "v1.0.5"
 }


### PR DESCRIPTION
This PR switches to using the `/model/allocation/summary` API endpoint based on the doc [here](https://docs.kubecost.com/apis/monitoring-apis/api-allocation#querying-with-summary-endpoint-to-view-condensed-payload-per-line-item)